### PR TITLE
Simulator dependency target, fix for Power architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,12 @@ doc:
 	done
 
 sim:
-	make -C src/cpp-simulator/src clean
-	make -C src/cpp-simulator/src
+	make -C src/qasm-simulator-cpp/src clean
+	make -C src/qasm-simulator-cpp/src
+
+# Build dependencies for the simulator target
+depend:
+	make -C src/qasm-simulator-cpp depend
 
 coverage_erase:
 	coverage erase

--- a/src/qasm-simulator-cpp/Makefile
+++ b/src/qasm-simulator-cpp/Makefile
@@ -5,5 +5,8 @@ all: sim
 sim: 
 	make -C src
 
+depend: 
+	./build_dependencies.sh
+
 clean:
 	make -C src clean

--- a/src/qasm-simulator-cpp/build_dependencies.sh
+++ b/src/qasm-simulator-cpp/build_dependencies.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------------
+# build_dependencies.sh
+# 
+# Dependency installer for qiskit-sdk-py/src/qasm-simulator-cpp
+# Running the script:
+#   1. Run the script directly
+#     ./build_dependencies.sh  
+#   2. Alternatively, build the make depend target (See the Makefile)
+#     make depend
+#
+# .. note:: Tested on Ubuntu 16.04 only. 
+# ------------------------------------------------------------------------------ 
+
+os_type=`uname -s`
+
+# Check who is the current user.
+USER=$(whoami)
+
+if [ ${USER} == "root" ]
+then
+  SUDOCMD=""
+else
+  SUDOCMD="sudo"
+fi
+
+# Check the OS Type
+echo "OS is $os_type"
+
+if [[ "$os_type" == "Darwin" ]]; then
+    ${SUDOCMD} xcode-select --install
+elif [[ "$os_type" == "Linux" ]]; then
+    echo "Installing dependencies on Linux"    
+    linux_distro=`cat /etc/*release | grep "ID_LIKE=" | cut -c9- | tr -d '"'`
+    if [[ "$linux_distro" == "debian" ]]; then
+        ${SUDOCMD} apt-get
+        ${SUDOCMD} apt-get install build-essential libblas-dev liblapack-dev
+    elif [[ "$linux_distro" == "fedora" ]]; then
+        ${SUDOCMD}  yum install devtoolset-6 blas blas-devel lapack lapack-devel
+        ${SUDOCMD}  scl enable devtoolset-6 bash
+    else
+        echo "Unsupported linux distro: $linux_distro"
+    fi
+fi

--- a/src/qasm-simulator-cpp/build_dependencies.sh
+++ b/src/qasm-simulator-cpp/build_dependencies.sh
@@ -35,10 +35,10 @@ elif [[ "$os_type" == "Linux" ]]; then
     linux_distro=`cat /etc/*release | grep "ID_LIKE=" | cut -c9- | tr -d '"'`
     if [[ "$linux_distro" == "debian" ]]; then
         ${SUDOCMD} apt-get update
-        ${SUDOCMD} apt-get install build-essential libblas-dev liblapack-dev
+        ${SUDOCMD} apt-get -y install build-essential libblas-dev liblapack-dev
     elif [[ "$linux_distro" == "fedora" ]]; then
         ${SUDOCMD} yum update
-        ${SUDOCMD} yum install devtoolset-6 blas blas-devel lapack lapack-devel
+        ${SUDOCMD} yum -y install devtoolset-6 blas blas-devel lapack lapack-devel
         ${SUDOCMD} scl enable devtoolset-6 bash
     else
         echo "Unsupported linux distro: $linux_distro"

--- a/src/qasm-simulator-cpp/build_dependencies.sh
+++ b/src/qasm-simulator-cpp/build_dependencies.sh
@@ -12,7 +12,7 @@
 #
 # .. note:: Tested on Ubuntu 16.04 only. 
 # ------------------------------------------------------------------------------ 
-
+set -ex
 os_type=`uname -s`
 
 # Check who is the current user.
@@ -34,11 +34,12 @@ elif [[ "$os_type" == "Linux" ]]; then
     echo "Installing dependencies on Linux"    
     linux_distro=`cat /etc/*release | grep "ID_LIKE=" | cut -c9- | tr -d '"'`
     if [[ "$linux_distro" == "debian" ]]; then
-        ${SUDOCMD} apt-get
+        ${SUDOCMD} apt-get update
         ${SUDOCMD} apt-get install build-essential libblas-dev liblapack-dev
     elif [[ "$linux_distro" == "fedora" ]]; then
-        ${SUDOCMD}  yum install devtoolset-6 blas blas-devel lapack lapack-devel
-        ${SUDOCMD}  scl enable devtoolset-6 bash
+        ${SUDOCMD} yum update
+        ${SUDOCMD} yum install devtoolset-6 blas blas-devel lapack lapack-devel
+        ${SUDOCMD} scl enable devtoolset-6 bash
     else
         echo "Unsupported linux distro: $linux_distro"
     fi

--- a/src/qasm-simulator-cpp/src/Makefile
+++ b/src/qasm-simulator-cpp/src/Makefile
@@ -13,7 +13,7 @@ ifeq ($(OS)$(GCC7),Darwin)
 endif
 
 # -march not supported on ppc64le (Power). Use -mcpu instead
-ARCH:$(shell uname -m)
+ARCH:=$(shell uname -m)
 ifeq ($(ARCH),ppc64le)
 	OPT = -O3 -mcpu=native -ffast-math
 endif

--- a/src/qasm-simulator-cpp/src/Makefile
+++ b/src/qasm-simulator-cpp/src/Makefile
@@ -50,6 +50,9 @@ sim: main.o
 sim_debug: main.o
 	$(CC) -g $(CPPFLAGS) $(DEFINES) -o ${OUTPUT_DIR}/qasm_simulator_cpp_debug ${OUTPUT_DIR}/main.o $(LIBS)
 
+depend: 
+	../build_dependencies.sh
+
 clean:
 	rm -rf $(OUTPUT_DIR)
 

--- a/src/qasm-simulator-cpp/src/Makefile
+++ b/src/qasm-simulator-cpp/src/Makefile
@@ -6,11 +6,16 @@ OUTPUT_DIR = ../../../out
 CC = g++
 
 # Use Homebrew GNU g++ for enabling OpenMP on macOS
-
 OS:=$(shell uname)
 GCC7:=$(shell g++-7 --version | grep ^'command not found')
 ifeq ($(OS)$(GCC7),Darwin)
 	CC = g++-7
+endif
+
+# -march not supported on ppc64le (Power). Use -mcpu instead
+ARCH:$(shell uname -m)
+ifeq ($(ARCH),ppc64le)
+	OPT = -O3 -mcpu=native -ffast-math
 endif
 
 # Check if compiler is Apple LLVM and doesn't support OpenMP


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just repeating the PR https://github.com/chriseclectic/qiskit-sdk-py/pull/2  , now for cpp-simulator branch based on @chriseclectic 's suggestion. 

Note: As these branches have significant code changes elsewhere, used git cherry-pick to pick relevant commits -- `git cherry-pick -x <commit_hash>` 

* This PR adds a new target to build dependencies (`make depend`) for the `qasm-cpp-simulator`. The dependencies are built using the information provided in the README. It has been tested on Ubuntu 16.04 only.
* Fixes the compilation error on `ppc64le` (use of `-march`)
* Fixes make sim target in `qiskit-sdk-py/Makefile`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.