### PR TITLE
Modernizing C++ code to new standards

### DIFF
--- a/src/qasm-simulator-cpp/src/backends/base_backend.hpp
+++ b/src/qasm-simulator-cpp/src/backends/base_backend.hpp
@@ -62,7 +62,7 @@ public:
     noise_flag = false;
     qreg_init_flag = false;
   };
-  virtual ~BaseBackend() {};
+  virtual ~BaseBackend() = default;
 
   /**
    * Execute a program on backend

--- a/src/qasm-simulator-cpp/src/backends/clifford_backend.hpp
+++ b/src/qasm-simulator-cpp/src/backends/clifford_backend.hpp
@@ -41,7 +41,7 @@ public:
   /************************
    * Constructors
    ************************/
-  CliffordBackend() : BaseBackend<Clifford>(){};
+  CliffordBackend() = default;
 
   /************************
    * BaseBackend Methods

--- a/src/qasm-simulator-cpp/src/backends/ideal_backend.hpp
+++ b/src/qasm-simulator-cpp/src/backends/ideal_backend.hpp
@@ -47,7 +47,7 @@ public:
    * Constructors
    ************************/
 
-  IdealBackend() : BaseBackend<QubitVector>(){};
+  IdealBackend() = default;
 
   /************************
    * BaseBackend Methods

--- a/src/qasm-simulator-cpp/src/backends/noise_models.hpp
+++ b/src/qasm-simulator-cpp/src/backends/noise_models.hpp
@@ -174,7 +174,7 @@ public:
    *  P(0|1) = p1, P(1|1) = 1-p1 for a 1 measurement outcome
    * @param p1: assignement error probability
    ***/
-  ReadoutError(double p1);
+  explicit ReadoutError(double p1);
 
   /***
    * Constructor: sets the readout assignment probablities from a vector of
@@ -210,7 +210,7 @@ public:
 
   // Constructors
   PauliChannel(){};
-  PauliChannel(uint_t nq) : n(nq){};
+  explicit PauliChannel(uint_t nq) : n(nq){};
   PauliChannel(uint_t nq, rvector_t p_pauli);
 
   // Get vector of error probabilities eg {pX, pY, pZ}

--- a/src/qasm-simulator-cpp/src/backends/qubit_backend.hpp
+++ b/src/qasm-simulator-cpp/src/backends/qubit_backend.hpp
@@ -50,27 +50,27 @@ public:
   /************************
    * BaseBackend Methods
    ************************/
-  void initialize(const Circuit &prog);
-  void qc_operation(const operation &op);
+  void initialize(const Circuit &prog) override;
+  void qc_operation(const operation &op) override;
 
 protected:
   /************************
    * Measurement and Reset
    ************************/
 
-  virtual void qc_reset(const uint_t qubit, const uint_t state = 0);
-  virtual void qc_measure(const uint_t qubit, const uint_t bit);
+  void qc_reset(const uint_t qubit, const uint_t state = 0) override;
+  void qc_measure(const uint_t qubit, const uint_t bit) override;
 
   /************************
    * 1-Qubit Gates
    ************************/
 
   // Single-qubit gates
-  virtual void qc_gate(const uint_t qubit, const double theta, const double phi,
-                       const double lambda);
-  virtual void qc_idle(const uint_t qubit);
-  virtual void qc_gate_x(const uint_t qubit);
-  virtual void qc_gate_y(const uint_t qubit);
+  void qc_gate(const uint_t qubit, const double theta, const double phi,
+                       const double lambda) override;
+  void qc_idle(const uint_t qubit);
+  void qc_gate_x(const uint_t qubit) override;
+  void qc_gate_y(const uint_t qubit) override;
 
   void qc_u0(const uint_t qubit, const double n);
   void qc_u1(const uint_t qubit, const double lambda);
@@ -79,11 +79,11 @@ protected:
              const double lambda);
 
   // 2-qubit gates
-  virtual void qc_cnot(const uint_t qctrl, const uint_t qtrgt);
-  virtual void qc_cz(const uint_t q0, const uint_t q1);
+  void qc_cnot(const uint_t qctrl, const uint_t qtrgt) override;
+  void qc_cz(const uint_t q0, const uint_t q1) override;
 
   // Gates with relaxation
-  virtual void qc_relax(const uint_t qubit, const double time);
+  void qc_relax(const uint_t qubit, const double time);
   void qc_matrix1_noise(const uint_t qubit, const cmatrix_t &U,
                         const GateError &err);
 

--- a/src/qasm-simulator-cpp/src/backends/rng_engine.hpp
+++ b/src/qasm-simulator-cpp/src/backends/rng_engine.hpp
@@ -102,7 +102,7 @@ public:
    * Seeded constructor initialize RNG engine with a fixed seed
    * @param seed integer to use as seed for mt19937 engine
    */
-  RngEngine(uint_t seed) { rng.seed(seed); };
+  explicit RngEngine(uint_t seed) { rng.seed(seed); };
 
 private:
   std::mt19937 rng; // Mersenne twister rng engine

--- a/src/qasm-simulator-cpp/src/engines/base_engine.hpp
+++ b/src/qasm-simulator-cpp/src/engines/base_engine.hpp
@@ -98,8 +98,8 @@ public:
   // Constructors
   //============================================================================
 
-  BaseEngine(){};
-  virtual ~BaseEngine(){};
+  BaseEngine() = default;
+  virtual ~BaseEngine() = default;
 
   //============================================================================
   // Methods

--- a/src/qasm-simulator-cpp/src/engines/vector_engine.hpp
+++ b/src/qasm-simulator-cpp/src/engines/vector_engine.hpp
@@ -57,8 +57,8 @@ class VectorEngine : public BaseEngine<QubitVector> {
 
 public:
   // Default constructor
-  VectorEngine(uint_t dim = 2) : BaseEngine<QubitVector>(), qudit_dim(dim){};
-
+  explicit VectorEngine(uint_t dim = 2)
+      : BaseEngine<QubitVector>(), qudit_dim(dim){};
   //============================================================================
   // Configuration
   //============================================================================

--- a/src/qasm-simulator-cpp/src/simulator.hpp
+++ b/src/qasm-simulator-cpp/src/simulator.hpp
@@ -180,12 +180,12 @@ json_t Simulator::run_circuit(Circuit &circ) const {
 
 // Thread number
 #ifdef _OPENMP
-    uint_t ncpus = omp_get_num_procs(); // OMP method
+    uint16_t ncpus = omp_get_num_procs(); // OMP method
     omp_set_nested(1);                  // allow nested parallel threads
 #else
-    uint_t ncpus = std::thread::hardware_concurrency(); // C++11 method
+    uint16_t ncpus = std::thread::hardware_concurrency(); // C++11 method
 #endif
-    ncpus = std::max(1ULL, ncpus); // check 0 edge case
+    ncpus = std::max(static_cast<uint16_t>(1), ncpus); // check 0 edge case
     int_t dq = (max_qubits > circ.nqubits) ? max_qubits - circ.nqubits : 0;
     uint_t threads = std::max<uint_t>(1UL, 2 * dq);
     if (circ.noise.ideal && circ.opt_meas)

--- a/src/qasm-simulator-cpp/src/utilities/binary_vector.hpp
+++ b/src/qasm-simulator-cpp/src/utilities/binary_vector.hpp
@@ -27,11 +27,12 @@ limitations under the License.
 #include <string>
 #include <vector>
 #include <cstdint>
+#include <stdint.h>
 
 namespace BV {
   
   // Types
-  using uint_t = unsigned long long;
+  using uint_t = uint64_t;
 
 /*******************************************************************************
  *
@@ -48,13 +49,13 @@ public:
 
   BinaryVector() : m_length(0), m_data(0){};
 
-  BinaryVector(uint_t length)
+  explicit BinaryVector(uint_t length)
       : m_length(length), m_data((length - 1) / blockSize + 1, 0){};
 
   BinaryVector(std::vector<uint_t> mdata)
       : m_length(mdata.size()), m_data(mdata){};
 
-  BinaryVector(std::string);
+  explicit BinaryVector(std::string);
 
   bool setLength(uint_t length);
 
@@ -95,16 +96,16 @@ inline bool operator==(const BinaryVector &lhs, const BinaryVector &rhs) {
   return lhs.isSame(rhs, true);
 }
 
-inline long gauss_eliminate(std::vector<BinaryVector> &M,
-                            const long start_col = 0)
+inline int64_t gauss_eliminate(std::vector<BinaryVector> &M,
+                            const int64_t start_col = 0)
 // returns the rank of M.
 // M[] has length nrows.
 // each M[i] must have the same length ncols.
 {
-  const long nrows = M.size();
-  const long ncols = M.front().getLength();
-  long rank = 0;
-  long k, r, i;
+  const int64_t nrows = M.size();
+  const int64_t ncols = M.front().getLength();
+  int64_t rank = 0;
+  int64_t k, r, i;
   for (k = start_col; k < ncols; k++) {
     i = -1;
     for (r = rank; r < nrows; r++) {

--- a/src/qasm-simulator-cpp/src/utilities/clifford.hpp
+++ b/src/qasm-simulator-cpp/src/utilities/clifford.hpp
@@ -42,7 +42,7 @@ struct PauliOperator {
   BinaryVector Z;
   bool phase;
   PauliOperator() : X(0), Z(0), phase(0){};
-  PauliOperator(uint64_t len) : X(len), Z(len), phase(0) {}
+  explicit PauliOperator(uint64_t len) : X(len), Z(len), phase(0) {}
 };
 
 /*******************************************************************************
@@ -54,8 +54,8 @@ struct PauliOperator {
 class Clifford {
 public:
   // Constructors
-  Clifford(){};
-  Clifford(const uint64_t nqubit);
+  Clifford() = default;
+  explicit Clifford(const uint64_t nqubit);
 
   // first n rows are destabilizers; last n rows are stabilizers
   inline PauliOperator &operator[](uint64_t j) { return table[j]; };

--- a/src/qasm-simulator-cpp/src/utilities/matrix.hpp
+++ b/src/qasm-simulator-cpp/src/utilities/matrix.hpp
@@ -211,11 +211,11 @@ public:
   // Constructors of matrix class
   matrix();
   matrix(size_t rows, size_t cols);
-  matrix(size_t size); // Makes a square matrix and rows = sqrt(size) columns =
-                       // sqrt(dims)
+  explicit matrix(size_t size); // Makes a square matrix and rows = sqrt(size) columns =
+                                // sqrt(dims)
   matrix(const matrix<T> &m);
   matrix(const matrix<T> &m, const char uplo);
-
+  
   // Initialize an empty matrix() to matrix(size_t  rows, size_t cols)
   void initialize(size_t rows, size_t cols);
   // Clear used memory
@@ -512,9 +512,7 @@ inline matrix<T> MOs::TensorProduct(const matrix<T> &A, const matrix<T> &B) {
 
 template <class T>
 inline matrix<T>::matrix()
-    : rows_(0), cols_(0), size_(0), LD_(0), outputstyle_(Matrix) {
-  mat_ = 0;
-}
+    : rows_(0), cols_(0), size_(0), LD_(0), outputstyle_(Matrix), mat_(nullptr) {}
 // constructs an empty matrix using the ....
 template <class T>
 inline matrix<T>::matrix(size_t rows, size_t cols)
@@ -624,7 +622,7 @@ template <class T> inline void matrix<T>::resize(size_t rows, size_t cols) {
 
 template <class T> inline matrix<T>::~matrix() {
   // destructor, deletes the matrix from memory when we leave the scope
-  if (mat_ != 0)
+  if (mat_ != nullptr)
     delete[](mat_);
 }
 template <class T>

--- a/src/qasm-simulator-cpp/src/utilities/qubit_vector.hpp
+++ b/src/qasm-simulator-cpp/src/utilities/qubit_vector.hpp
@@ -41,7 +41,7 @@ namespace QV {
 // Types
 using TI::TensorIndex;
 using TI::uint_t;
-using omp_int_t = long long int; // signed int for OpenMP 2.0 on msvc
+using omp_int_t = int64_t; // signed int for OpenMP 2.0 on msvc
 using complex_t = std::complex<double>;
 using cvector_t = std::vector<complex_t>;
 using rvector_t = std::vector<double>;
@@ -60,7 +60,7 @@ public:
    * Constructors
    ************************/
 
-  QubitVector(size_t num_qubits = 0);
+  explicit QubitVector(size_t num_qubits = 0);
   QubitVector(const cvector_t &vec);
   QubitVector(const rvector_t &vec);
 

--- a/src/qasm-simulator-cpp/src/utilities/tensor_index.hpp
+++ b/src/qasm-simulator-cpp/src/utilities/tensor_index.hpp
@@ -34,7 +34,7 @@ limitations under the License.
 
 namespace TI {
   
-  using uint_t = unsigned long long;
+  using uint_t = uint64_t;
 
 /*******************************************************************************
  *

--- a/src/qasm-simulator-cpp/src/utilities/types.hpp
+++ b/src/qasm-simulator-cpp/src/utilities/types.hpp
@@ -31,6 +31,7 @@ limitations under the License.
 #include <iostream>
 #include <map>
 #include <vector>
+#include <stdint.h>
 
 #include "qubit_vector.hpp"  // N-qubit vector class
 #include "binary_vector.hpp" // Binary Vector class
@@ -45,8 +46,8 @@ limitations under the License.
  ******************************************************************************/
 
 // Numeric Types
-using int_t = long long;
-using uint_t = unsigned long long;
+using int_t = int64_t;
+using uint_t = uint64_t;
 using complex_t = std::complex<double>;
 using cvector_t = std::vector<complex_t>;
 using rvector_t = std::vector<double>;


### PR DESCRIPTION
- Using `= default` to let decide the compile which is the better minimum
- Using `explicit` for ctors with one argument, to avoid unwanted implicit conversions
- Using size-safe types
